### PR TITLE
Handle Windows Subsystem for Linux spuriously adding 'none' to `ip r`

### DIFF
--- a/src/inet_ext.erl
+++ b/src/inet_ext.erl
@@ -57,7 +57,7 @@ gateway_for(IName0) ->
     end.
 
 gateway_for(IName, linux) ->
-    Cmd = "ip r | grep " ++ IName ++ " | grep default | cut -d ' ' -f 3",
+    Cmd = "ip r | grep " ++ IName ++ " | grep default | sed 's/^none //' | cut -d ' ' -f 3",
     parse_result(inet_ext_lib:run(Cmd));
 gateway_for(IName, darwin) ->
     Cmd = "ipconfig getoption " ++ IName ++ " router",


### PR DESCRIPTION
As described in https://github.com/Microsoft/WSL/issues/2516 WSL is
incorrectly prefixing all `ip r` output lines with 'none'. This addition
of a sed to the pipeline simply removes any leading 'none'.